### PR TITLE
split the output of net share to exclude error

### DIFF
--- a/modules/net_share/lib/puppet/provider/net_share/net_share.rb
+++ b/modules/net_share/lib/puppet/provider/net_share/net_share.rb
@@ -60,7 +60,7 @@ Puppet::Type.type(:net_share).provide(:net_share) do
   def self.query(name)
     cmd = [command(:net), 'share', name]
     output = execute(cmd, { :failonfail => false })
-
+	output = output.split("\n")
     properties = {}
     properties[:name] = name
 


### PR DESCRIPTION
Added explicit split of the output variable to get rid of error
Error: Could not prefetch net_share provider 'net_share': undefined method `each' for #Puppet::Util::Execution::ProcessOutput:0x00000003d79738
